### PR TITLE
Drop the value manually, runs to completion

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -23,6 +23,9 @@ async fn mutex_task<T>(
     mut fut_channel: mpsc::UnboundedReceiver<FutItem>,
 ) {
     let mut futs = FuturesUnordered::new();
+    // Re-bind 'value' so that it is dropped before futs.
+    // That will ensure .termination() completes only once the value's drop has finished.
+    // let mut value = value;
     loop {
         // Obtain an item
         let current_item = loop {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -18,14 +18,14 @@ type MutItem<T> = Box<dyn for<'a> FnOnce(&'a mut T) -> BoxFuture<'a, bool> + Sen
 type FutItem = BoxFuture<'static, ()>;
 
 async fn mutex_task<T>(
-    mut value: T,
+    value: T,
     mut mut_channel: mpsc::UnboundedReceiver<MutItem<T>>,
     mut fut_channel: mpsc::UnboundedReceiver<FutItem>,
 ) {
     let mut futs = FuturesUnordered::new();
     // Re-bind 'value' so that it is dropped before futs.
     // That will ensure .termination() completes only once the value's drop has finished.
-    // let mut value = value;
+    let mut value = value;
     loop {
         // Obtain an item
         let current_item = loop {

--- a/src/runtimes/async_std.rs
+++ b/src/runtimes/async_std.rs
@@ -61,8 +61,9 @@ mod tests {
     // Tests that .termination() waits for the Actor to be dropped
     #[async_std::test]
     async fn wait_drop_test() {
+        use std::time::{Duration, Instant};
         struct WaitDrop {
-            tx: std::sync::mpsc::Sender<u32>,
+            tx: std::sync::mpsc::SyncSender<u32>,
         }
         impl Actor for WaitDrop {}
         impl Drop for WaitDrop {
@@ -71,11 +72,10 @@ mod tests {
                 self.tx.send(5).unwrap();
             }
         }
-
-        let (tx, rx) = std::sync::mpsc::channel();
-        let addr = spawn_actor(WaitDrop { tx});
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let addr = spawn_actor(WaitDrop { tx });
         let ended = addr.termination();
-        std::mem::drop(addr);
+        drop(addr);
         ended.await;
         let res = rx.try_recv();
         assert_eq!(res, Ok(5));

--- a/src/runtimes/async_std.rs
+++ b/src/runtimes/async_std.rs
@@ -57,4 +57,27 @@ mod tests {
 
         assert_eq!(res, "test");
     }
+
+    // Tests that .termination() waits for the Actor to be dropped
+    #[async_std::test]
+    async fn wait_drop_test() {
+        struct WaitDrop {
+            tx: std::sync::mpsc::Sender<u32>,
+        }
+        impl Actor for WaitDrop {}
+        impl Drop for WaitDrop {
+            fn drop(&mut self) {
+                std::thread::sleep(Duration::from_millis(100));
+                self.tx.send(5).unwrap();
+            }
+        }
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let addr = spawn_actor(WaitDrop { tx});
+        let ended = addr.termination();
+        std::mem::drop(addr);
+        ended.await;
+        let res = rx.try_recv();
+        assert_eq!(res, Ok(5));
+    }
 }


### PR DESCRIPTION
In my testing this fixes the problem of #6, though I'm not sure if there would be other side-effects of the change