### PR TITLE
[Not Working] Upgrade tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ tracing = ["tynm"]
 futures = "0.3.6"
 async-trait = "0.1.41"
 log = "0.4.11"
-tokio = { version = "0.2.22", features = ["rt-core", "time"], optional = true }
+tokio = { version = "1.0.1", features = ["rt", "time"], optional = true }
 async-std = { version = "1.6.5", optional = true }
 tynm = { version = "0.1.4", optional = true }
 
 [dev-dependencies]
-tokio = { version = "0.2.22", features = ["macros", "blocking"] }
+tokio = { version = "1.0.1", features = ["macros", "rt"] }
 async-std = { version = "1.6.5", features = ["attributes"] }
 
 [[example]]

--- a/src/runtimes/tokio.rs
+++ b/src/runtimes/tokio.rs
@@ -27,9 +27,10 @@ impl Spawn for Runtime {
 }
 
 impl timer::SupportsTimers for Runtime {
-    type Delay = tokio::time::Delay;
-    fn delay(&self, deadline: Instant) -> Self::Delay {
-        tokio::time::delay_until(deadline.into())
+    type Delay = tokio::time::Sleep;
+
+    fn delay(&self, deadline: Instant) -> Self::Delay{
+        tokio::time::sleep_until(deadline.into())
     }
 }
 


### PR DESCRIPTION
I thought I would try and attempt to upgrade Tokio to 1.0. 

I was unable. The old `Delay` was `Unpin` the new `Sleep` which replaced `Delay` is [`!Unpin`](https://github.com/tokio-rs/tokio/pull/3330) and I’m not sure how to deal with that. 

Posting this as reference